### PR TITLE
Added link to Eclipse Lyo

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ ARCHIVE - inactive projects or old academic projects that may lack soruce code
 - [foafssl-java](https://github.com/bblfish/foafssl-java)
 - [soarql-dl-api](https://github.com/protegeproject/sparql-dl-api) - A query engine for SPARQL-DL.
 - [nxparser](https://github.com/nxparser/nxparser) - Java parsers for different RDF serialisations + API + tools + JAX-RS integration.
+- [Eclipse Lyo](https://www.eclipse.org/lyo/)
 
 ### Python
 


### PR DESCRIPTION
Eclipse Lyo supports Java developers with the development of REST-based servers and clients that need to share heterogeneous information as RDF resources. It supports Linked Data principles and OSLC.