### PR TITLE
fix OWL-API endonym, add link to ONT-API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1052,7 +1052,8 @@ OS - OpenSource
 - [sesametools](https://github.com/joshsh/sesametools) - A collection of utilities for use with OpenRDF Sesame (as of recently, Eclipse RDF4J).
 - [DEER](https://github.com/dice-group/DEER) - RDF Dataset Enrichment Framework.
 - [levelgraph-jsonld](https://github.com/mcollina/levelgraph-jsonld) - The Object Document Mapper for LevelGraph based on JSON-LD
-- [owlapi](https://github.com/owlcs/owlapi) - The OWL API is a Java API for creating, manipulating and serialising OWL Ontologies.
+- [OWL-API](https://github.com/owlcs/owlapi) - The OWL API is a Java API for creating, manipulating and serialising OWL Ontologies.
+- [ONT-API](https://github.com/avicomp/ont-api) - a Jena based OWL API implementation.
 - [LODGrefine](https://github.com/sparkica/LODGrefine) - LOD-enabled Google Refine: linked open data related extensions included.
 - [stardog.js](https://github.com/stardog-union/stardog.js)
 - [stardog-groovy](https://github.com/stardog-union/stardog-groovy)


### PR DESCRIPTION
add a reference to ONT-API (an extended Jena-based OWL-API impl), fix OWL-API name (it seems 'owlapi' in lowercase is not quite correct)