### PR TITLE
Fixed name of PHP library (semsol => ARC2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -865,7 +865,7 @@ OS - OpenSource
 ### PHP
 
 - [EasyRdf](http://www.easyrdf.org/)
-- [semsol](https://github.com/semsol/arc2/wiki)
+- [ARC2](https://github.com/semsol/arc2/wiki)
 - [PHP-SPARQL-Lib](https://github.com/cgutteridge/PHP-SPARQL-Lib)
 - [Graphite](http://graphite.ecs.soton.ac.uk/)
 - [sparqllib](http://graphite.ecs.soton.ac.uk/sparqllib/)


### PR DESCRIPTION
The project is called ARC2 and their main developer is @semsol.

Source: https://github.com/semsol/arc2#arc2