### PR TITLE
Added fork to abandoned EasyRdf project (PHP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,7 +889,8 @@ OS - OpenSource
 
 ### PHP
 
-- [EasyRdf](http://www.easyrdf.org/)
+- [EasyRdf](http://www.easyrdf.org/) - abandoned by the author
+  - [sweetrdf/easyrdf](https://github.com/sweetrdf/easyrdf) - Maintained fork, fully compatible to EasyRdf v1.x, run on latest PHP versions.
 - [ARC2](https://github.com/semsol/arc2/wiki)
 - [PHP-SPARQL-Lib](https://github.com/cgutteridge/PHP-SPARQL-Lib)
 - [Graphite](http://graphite.ecs.soton.ac.uk/)

--- a/README.md
+++ b/README.md
@@ -890,7 +890,7 @@ OS - OpenSource
 ### PHP
 
 - [EasyRdf](http://www.easyrdf.org/) - abandoned by the author
-  - [sweetrdf/easyrdf](https://github.com/sweetrdf/easyrdf) - Maintained fork, fully compatible to EasyRdf v1.x, run on latest PHP versions.
+  - [sweetrdf/easyrdf](https://github.com/sweetrdf/easyrdf) - Maintained fork, fully compatible to EasyRdf v1.x, runs on latest PHP versions.
 - [ARC2](https://github.com/semsol/arc2/wiki)
 - [PHP-SPARQL-Lib](https://github.com/cgutteridge/PHP-SPARQL-Lib)
 - [Graphite](http://graphite.ecs.soton.ac.uk/)


### PR DESCRIPTION
EasyRdf repository has [8 open pull requests](https://github.com/easyrdf/easyrdf/pulls) and the author being inactive for over 2 years. There is no development and feedback (latest commit is from Aug 31, 2021). In my opinion this situation means the project is abandoned.

The fork I added is maintained by myself and aims for users, who are forced to use EasyRdf. Because EasyRdf is not maintained anymore, there are no adaptions for PHP 8.1+. My fork closes that gap and contains further tweaks and optimizations also.