### PR TITLE
Added Emacs Literate Ontology Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1000,6 +1000,7 @@ OS - OpenSource
 - [sparql-mode](https://github.com/ljos/sparql-mode)
 - [ttl-mode](https://github.com/jeeger/ttl-mode) - Supports both ttl and n3, indentation, some electric punctuation and hungry delete.
 - [nxml-mode](https://www.emacswiki.org/emacs/NxmlMode) - nxml-mode is a major mode for editing XML
+- [ELOT](https://github.com/johanwk/elot) - Emacs Literate Ontology Tool, write OWL ontologies using org-mode
 
 ### JetBrains IDEs: Intellij IDEA, PyCharm, etc.
 


### PR DESCRIPTION
ELOT makes it convenient to develop OWL ontologies using Emacs' org-mode. Documentation, diagrams, queries, export to HTML and PDF as well as OWL documents.