### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,7 +808,7 @@ OS - OpenSource
 - [Validating RDF Data](http://book.validatingrdf.com/)
 - [Learning SPARQL](http://www.learningsparql.com/)
 - [A Developer's Guide to the Semantic Web, 2014,2nd Ed](https://www.springer.com/us/book/9783662437957)
-- [Ontology Engineering](https://www.morganclaypool.com/doi/abs/10.2200/S00834ED1V01Y201802WBE018)
+- [Ontology Engineering](https://www.amazon.com/Ontology-Engineering-Synthesis-Lectures-Semantic/dp/1681733102/)
 - [The Data-Centric Revolution](https://www.amazon.co.uk/Data-Centric-Revolution-Restoring-Enterprise-Information/dp/1634625404)
 - [An Introduction to Ontology Engineering, Keet, 2020, v1.5](https://people.cs.uct.ac.za/~mkeet/OEbook/) [[1](https://open.umn.edu/opentextbooks/textbooks/590)]
 


### PR DESCRIPTION
Revised link to 'Ontology Engineering' as Morgan & Claypool is now part of Springer Nature, but the book is also available on Amazon