### PR TITLE
Add RDF Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,6 +795,7 @@ OS - OpenSource
 - [OOPS! (Ontology Pitfall Scanner!)](http://oops.linkeddata.es/) - a web application to detect (semi)automatically 33 pitfalls or errors in ontologies. A web service is also provided.
 - [Cameo Concept Modeler](https://www.nomagic.com/product-addons/magicdraw-addons/cameo-concept-modeler-plugin#key-benefits) - a cross-platform app for OWL ontology modeling, visualization, and natural-language validation
 - [Mobi](https://mobi.inovexcorp.com) - [Open Source](https://github.com/inovexcorp/mobi) (with an optional Enterprise version) system for developing ontologies and skos ocabularies with native graph versioning that enables a git-inspired workflow. More info [here](https://inovexcorp.github.io/mobi-docs/).
+- [RDF Studio](https://rdf-studio.com) - Free web-based IDE with an advanced visual OWL/RDFS ontology editor, SHACL shapes validator and auto-generator, ontology maturity scoring, and schema-data drift detection.
 
 ## Reasoners
 
@@ -1134,6 +1135,7 @@ OS - OpenSource
 - [RdfGlance](https://github.com/xdobry/rdfglance) - Fast desktop RDF graph visualization and data viewer programmed in Rust
 - [G.V](https://gdotv.com) - ($/(F)) G dot V Graph Database Exploration and Visualization UI for SPARQL, Cypher and Gremlin
 - [SemSpect](https://www.semspect.de) - Graph exploration and data-driven no-code querying tool for Neo4j and RDF data
+- [RDF Studio](https://rdf-studio.com) - Free web-based IDE with interactive knowledge graph visualization, faceted search auto-generated from OWL ontologies, SPARQL 1.1 editor, and multi-database support for Oxigraph, GraphDB, and any SPARQL endpoint.
 
 ## Data Cube
 


### PR DESCRIPTION
Hi guys, I kindly request if you could add my RDF Studio to your list.
It's a free web-based IDE for browsing, querying, and editing RDF knowledge graphs.

**Here's what it is:**
- Interactive knowledge graph visualization with faceted search auto-generated from OWL ontologies
- Advanced visual OWL/RDFS ontology editor with SHACL shapes validator and auto-generator
- SPARQL 1.1 editor with syntax highlighting, autocomplete, and 60+ ready-to-run example queries
- Ontology maturity scoring and schema-data drift detection
- Multi-database support: Oxigraph, GraphDB, and any SPARQL 1.1 endpoint
- It's great for training, because it comes with a full set of executable sparql queries to answer multiple business competence questions (EKGF Use Case Stories). 

**Live app:** https://rdf-studio.com

Added to: **Visualization** and **Ontology Development** sections.