### PR TITLE
Add rdf reasoner konclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,6 +815,7 @@ OS - OpenSource
 - [eye](https://github.com/josd/eye) - Euler Yet another proof Engine.
 - [Sequoia](https://github.com/andrewdbate/Sequoia) - Sequoia is a consequence-based OWL 2 DL Reasoner supporting multithreaded reasoning.
 - [konclude](http://www.derivo.de/en/produkte/konclude.html) - Konclude is a high-performance reasoner for large and expressive ontologies.
+- [rdf-reasoner-konclude](https://github.com/ThHanke/rdf-reasoner-konclude) - Konclude OWL-DL tableau reasoning kernel compiled to WebAssembly. Runs in browsers and Node.js; async TypeScript API with RDF.js Quad types and N3.js Store integration.
 - [owlproofs](https://github.com/klinovp/owlproofs) - Extension to the OWL API to request proofs of entailments from the reasoner.
 
 ## Books

--- a/README.md
+++ b/README.md
@@ -815,7 +815,6 @@ OS - OpenSource
 - [eye](https://github.com/josd/eye) - Euler Yet another proof Engine.
 - [Sequoia](https://github.com/andrewdbate/Sequoia) - Sequoia is a consequence-based OWL 2 DL Reasoner supporting multithreaded reasoning.
 - [konclude](http://www.derivo.de/en/produkte/konclude.html) - Konclude is a high-performance reasoner for large and expressive ontologies.
-- [rdf-reasoner-konclude](https://github.com/ThHanke/rdf-reasoner-konclude) - Konclude OWL-DL tableau reasoning kernel compiled to WebAssembly. Runs in browsers and Node.js; async TypeScript API with RDF.js Quad types and N3.js Store integration.
 - [owlproofs](https://github.com/klinovp/owlproofs) - Extension to the OWL API to request proofs of entailments from the reasoner.
 
 ## Books

--- a/README.md
+++ b/README.md
@@ -815,6 +815,7 @@ OS - OpenSource
 - [eye](https://github.com/josd/eye) - Euler Yet another proof Engine.
 - [Sequoia](https://github.com/andrewdbate/Sequoia) - Sequoia is a consequence-based OWL 2 DL Reasoner supporting multithreaded reasoning.
 - [konclude](http://www.derivo.de/en/produkte/konclude.html) - Konclude is a high-performance reasoner for large and expressive ontologies.
+- [rdf-reasoner-konclude](https://www.npmjs.com/package/rdf-reasoner-konclude) - Konclude OWL-DL tableau reasoning kernel compiled to WebAssembly. Runs in browsers and Node.js; async TypeScript API with RDF.js Quad types and N3.js Store integration.
 - [owlproofs](https://github.com/klinovp/owlproofs) - Extension to the OWL API to request proofs of entailments from the reasoner.
 
 ## Books


### PR DESCRIPTION
Adds [rdf-reasoner-konclude](https://github.com/ThHanke/rdf-reasoner-konclude), a WebAssembly port of the Konclude OWL-DL tableau reasoning kernel.

- Runs in browsers (Web Workers) and Node.js 18+
- Full OWL-DL / SROIQ expressivity via tableau reasoning
- Async TypeScript API with RDF.js Quad types and N3.js Store integration
- npm: `npm install rdf-reasoner-konclude n3`

To my knowledge the only npm-published OWL-DL reasoner for browser/worker environments.
