### PR TITLE
feat: add TWZRD Agent Intel MCP to Platforms section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1193,6 +1193,8 @@ OS - OpenSource
 - [pyLDAPI](https://github.com/rdflib/pyLDAPI) - A Python [rdflib](https://github.com/rdflib/RDFlib/)-based API framework for Linked Data via the W3C's [Content Negotiation by Profile](https://w3c.github.io/dx-connegp/connegp/)
 - [Chimera](https://github.com/cefriel/chimera) - A framework providing Apache Camel components to support data conversion to/from RDF and service integration with RDF graphs
 
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - On-chain trust scoring platform for AI agents on Solana. Provides identity verification for agents accessing knowledge graph and ontology APIs via x402 micropayments. Free MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
+
 ## Tools
 
 - [tawny-owl](https://github.com/phillord/tawny-owl) - Build OWL Ontologies in a Programmatic Environment.


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Platforms** section.

TWZRD Agent Intel is an on-chain trust scoring platform for AI agents on Solana. It provides identity verification for agents accessing knowledge graph, ontology, and semantic web APIs via x402 micropayments — enabling trusted agent-to-API interactions at the Linked Data layer.

**Free MCP integration:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

**Relevance:** As knowledge graph APIs add x402 access control for AI agents, TWZRD provides the trust layer agents need before making paid ontology or graph database API calls.