### PR TITLE
Add open-kgo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,6 +1010,7 @@ OS - OpenSource
 - [semantic-python-overview](https://github.com/pysemtec/semantic-python-overview) - List of Python specific semantic web tools and resources. 
 - [pycottas](https://github.com/arenas-guerrero-julian/pycottas) - Python library for working with COTTAS files.
 - [pyjelly](https://github.com/Jelly-RDF/pyjelly) – Python implementation of the high-performance [Jelly binary format](https://w3id.org/jelly), supporting rdflib.
+- [open-kgo](https://github.com/mloda-ai/open-kgo) - Unified Python API over nine knowledge-graph backend families (including RDF/SPARQL) that validates each traversal against a declared ontology and rejects semantically invalid hops.
 
 ### R
 


### PR DESCRIPTION
Adds [open-kgo](https://github.com/mloda-ai/open-kgo) to the Programming > Python section.

Why it's a useful addition: it gives a single Python API across nine knowledge-graph backend families (including RDF/SPARQL via rdflib), and validates each graph traversal against a declared ontology, rejecting semantically invalid hops at query time rather than post-hoc. Apache-2.0 licensed, documented, tested (tox: pytest + ruff + mypy --strict + bandit), and the demos run offline with no external services.