### PR TITLE
Add Reactodia link to tools list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1120,6 +1120,7 @@ OS - OpenSource
 - [visualRDF](https://github.com/alangrafu/visualRDF)
 - [rdfdot](https://github.com/wastl/rdfdot) - Tools for drawing graphs from RDF files with GraphViz.
 - [ontodia](https://github.com/ontodia-org/ontodia) - Ontodia data diagraming library.
+- [Reactodia](https://github.com/reactodia/reactodia-workspace) - Ontodia fork with additional features such as grouping and annotations
 - [rdfpuml](https://github.com/VladimirAlexiev/rdf2rml) - True RDF Diagrams.
 - [sgvizler](http://mgskjaeveland.github.io/sgvizler/) - JavaScript library for visualizing SPARQL query results in SVG.
 - [OWLGrEd](http://owlgred.lumii.lv/) - UML style graphical editor for OWL ontologies.


### PR DESCRIPTION
This pull request adds a new tool to the list of open source RDF visualization libraries in the `README.md`. The addition highlights a fork of Ontodia called Reactodia, which includes extra features.

Open Source RDF Visualization Tools:

* Added `Reactodia` (a fork of Ontodia) to the list, noting its additional features such as grouping and annotations.

Has actually quite useful features