### PR TITLE
Add Ontology Engineering Curriculum

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,7 @@ OS - OpenSource
 - [Coursera - Web of Data](https://www.coursera.org/learn/web-data/) - A joint initiative between EIT Digital, Université de Nice Sophia-Antipolis / Université Côte d'Azur and INRIA - introduces the Linked Data standards and principles that provide the foundation of the Semantic web.
 - [Linked Data Patterns](http://patterns.dataincubator.org/book/index.html)
 - [OBO Academy](https://oboacademy.github.io/obook/) - open, online, self-paced training materials on semantic engineering, ontology curation and ontology development.
+- [Ontology Engineering Curriculum](https://github.com/fabio-rovai/ontology-curriculum) - A free 147-lesson curriculum published as OWL 2 and SKOS, where every lesson is crosswalked to the standard it teaches and a SHACL release gate runs in CI.
 
 ## Ontology Development
 


### PR DESCRIPTION
Adds one link to **Educational**.

`- [Ontology Engineering Curriculum](https://github.com/fabio-rovai/ontology-curriculum) - A free 147-lesson curriculum published as OWL 2 and SKOS, where every lesson is crosswalked to the standard it teaches and a SHACL release gate runs in CI.`

I am the author.

**Why it belongs in Educational.** The section carries OBO Academy and the Coursera Web of Data course. This is the same category and a larger one: 9 courses, 147 lessons, free, no payment step.

**What it adds that nothing else in the section does.** The curriculum is itself published as an ontology, so the syllabus is queryable rather than only readable. Each lesson node carries `cur:teaches` pointing at the normative IRI of the standard it covers, across RDF, RDFS, OWL 2, SKOS, SHACL, SPARQL, PROV-O and SSSOM. "Which lessons cover SHACL" is a SPARQL query.

The crosswalk is regex over lesson titles, documented in `rdfs:comment` on the property with the patterns in `crosswalk.json`, so the derivation is auditable rather than asserted.

`validate.py` runs the SHACL shapes and then a closed-world check SHACL cannot do: every object of `cur:teaches` must be a declared `cur:Standard`, so a typo cannot ship as a term denoting nothing. It runs in GitHub Actions on every push and it caught a real defect on its first run, recorded in the README.

Against your quality standards: documented, tested in CI, actively maintained, CC-BY-4.0.
