### PR TITLE
Add PurRDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1045,6 +1045,7 @@ OS - OpenSource
 - [owlish](https://github.com/field33/owlish) - An OWL library in Rust modeled on the OWL functional syntax.
 - [RDFtk](https://github.com/johnstonskj/rust-rdftk) - An RDF Toolkit for Rust
 - [hdt-rs](https://github.com/KonradHoeffner/hdt) - Read and query [HDT](https://www.rdfhdt.org/)
+- [PurRDF](https://github.com/Blackcat-Informatics/purrdf) - RDF 1.2 engine with SPARQL, SHACL, ShEx and entailment, exposing one identical behaviour in Rust, Python, WebAssembly and C.
 
 ### Scala
 


### PR DESCRIPTION
PurRDF is an open-source RDF 1.2 toolkit and SPARQL engine implemented in
Rust, with additional Python, WebAssembly/JavaScript, and C surfaces.

I placed it under Programming → Rust because Rust is the implementation core
and this avoids duplicating the same project across the SPARQL, Geo, SHACL,
database, and host-language sections.

PurRDF reached 1.1.0 in September 2026 and is published under MIT OR
Apache-2.0. I am a maintainer of the project.